### PR TITLE
bugfix in the integration between fuse & json-schema.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ fabric.properties
 # VSCode
 *.code-workspace
 .vscode
+
+# VIM
+*.swp

--- a/src/confusefs.cpp
+++ b/src/confusefs.cpp
@@ -225,7 +225,7 @@ int confusefs::stat(fuse_ino_t ino, struct stat *stbuf)
     {
         stbuf->st_mode = S_IFREG | 0444;
         stbuf->st_nlink = 1;
-        stbuf->st_size = m_inodes[ino].length();
+        stbuf->st_size = MAX_READ_DATA_SIZE;
     }
 
     return 0;

--- a/src/confusefs.hpp
+++ b/src/confusefs.hpp
@@ -13,6 +13,23 @@ namespace confusefs
 {
 using json = nlohmann::json;
 
+/*
+ * The Linux kernel has a state-machine which limits the data size that can be
+ * returned from the syscall `read` to the minimal size of the following sizes:
+ *  1) the size the user whom invoked the syscall, i.e. the `count` argument to
+ *     `read` syscall.
+ *  2) the actual size of the file.
+ *  3) the size of the file as stated in `stat` syscall, it's only logical to
+ *     limit the size which can be returned from `read` to the size which had been
+ *     stated earlier in the dedicated syscall to tell the size of  the file...
+ *  This constant will be used as the size stated in `stat` syscall since we
+ *  can't determine the size of a configuration file from the schema all the
+ *  time (some field are not bounded by any limit, such as strings with
+ *  maxlength and big-nums, i.e. integers).
+ *  As a result the size of a configuration file will be limited to 256 bytes.
+ */
+constexpr unsigned int MAX_READ_DATA_SIZE = 256;
+
 class confusefs
 {
    public:


### PR DESCRIPTION
before this commit the max size of data that could be returned from the
syscall `read` was limited to the path of the file within the confusefs
virtual filesystem, now it's limited to 256 bytes since some field of
the json-schema don't have a size limitation.

Signed-off-by: Eyal Royee <eyalroyee@gmail.com>